### PR TITLE
 fix read function name error

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
         cert := os.Getenv("HTTPS_CERT")
         key := os.Getenv("HTTPS_KEY")
 
-        //indexHtml := io.ReadFile("./index.html")
+        //indexHtml := os.ReadFile("./index.html")
 
         app := fiber.New()
         app.Use(logger.New())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated file reading method to use `os.ReadFile` instead of `io.ReadFile` for improved compatibility and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->